### PR TITLE
Re-enable CLI parser option tests for subcommand flow

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,25 +62,25 @@ def test_parse_disable_current_flag():
     assert options.disable_current is True
 
 
-# TODO: Revisit these test after cli refactored
-
-# def test_default_desc():
-#     options = cli.parse_args(['version'])
-#     assert options.desc is None
-#     assert not options.auto_desc
+def test_default_desc():
+    options = cli.parse_args(['version'])
+    assert options.desc is None
+    assert not options.auto_desc
 
 
-# def test_parse_desc():
-#     description = 'Bastion Host'
-#     options = cli.parse_args(['--desc', description])
-#     assert options.desc == description
+def test_parse_desc():
+    description = 'Bastion Host'
+    options = cli.parse_args(['add', '--desc', description, '203.0.113.10/32'])
+    assert options.command == 'add'
+    assert options.desc == description
 
 
-# def test_parse_autodesc():
-#     options = cli.parse_args(['--auto-desc'])
-#     assert options.auto_desc
-#
-#
-# def test_parse_conflict():
-#     with pytest.raises(SystemExit):
-#         cli.parse_args(['--auto-desc', '--desc', 'conflict'])
+def test_parse_autodesc():
+    options = cli.parse_args(['add-current', '--auto-desc'])
+    assert options.command == 'add-current'
+    assert options.auto_desc
+
+
+def test_parse_conflict():
+    with pytest.raises(SystemExit):
+        cli.parse_args(['add-current', '--auto-desc', '--desc', 'conflict'])


### PR DESCRIPTION
The CLI refactor moved `--desc` and `--auto-desc` under subcommands, but related parser tests in `tests/test_cli.py` were left commented out. This change restores coverage for that behavior so parser expectations stay explicit and maintainable.

## What changed
1. Re-enabled four previously commented parser tests (`default_desc`, `parse_desc`, `parse_autodesc`, `parse_conflict`).
2. Updated argument shapes to match the current subcommand model:
   - `--desc` is validated via `add --desc ... <cidr>`
   - `--auto-desc` is validated via `add-current --auto-desc`
   - mutual exclusion is validated via `add-current --auto-desc --desc ...`
3. Added command assertions where useful to confirm parsing lands on the intended subcommand.

This is intentionally a test-only change; runtime CLI behavior is unchanged.