### PR TITLE
Fix remaining code scanning alerts

### DIFF
--- a/awswl/commands.py
+++ b/awswl/commands.py
@@ -227,18 +227,19 @@ def get_security_group(options: Namespace):
     ec2 = boto3.resource('ec2')
     if options.sgid:
         return ec2.SecurityGroup(options.sgid)
-    else:
-        groups = get_matching_security_groups(options.sg_name)
-        if len(groups) == 0:
-            print(f"Could not find security group with name {options.sg_name}\n")
-        elif len(groups) == 1:
-            [name, sgid] = groups[0]
-            print(f"Using security group {name} ({sgid}).\n")
-            return ec2.SecurityGroup(sgid)
-        else:
-            print(f"Found {len(groups)} security groups matching name: ")
-            for group in groups:
-                print(f"- {group[0]} ({group[1]})")
+    groups = get_matching_security_groups(options.sg_name)
+    if len(groups) == 0:
+        print(f"Could not find security group with name {options.sg_name}\n")
+        return None
+    if len(groups) == 1:
+        [name, sgid] = groups[0]
+        print(f"Using security group {name} ({sgid}).\n")
+        return ec2.SecurityGroup(sgid)
+
+    print(f"Found {len(groups)} security groups matching name: ")
+    for group in groups:
+        print(f"- {group[0]} ({group[1]})")
+    return None
 
 
 def get_matching_security_groups(sg_name):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,7 +7,7 @@ import boto3
 from moto import mock_aws
 
 import awswl
-from awswl import commands
+import awswl.commands as commands
 
 
 def assert_list_output(opt, matches, capsys):


### PR DESCRIPTION
## Summary
- fix mixed return paths in `get_security_group` by returning `None` explicitly for non-match/multi-match cases
- switch `tests/test_commands.py` to consistent import style for `awswl.commands`

## Alerts addressed
- `py/mixed-returns` in `awswl/commands.py`
- `py/import-and-import-from` in `tests/test_commands.py`